### PR TITLE
Link to docs in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		}
 	],
 	"support": {
-        "docs": "https://docs.typo3.org/p/stefanfroemken/ext-kickstarter/main/en-us/Index.html"
+        "docs": "https://docs.typo3.org/p/stefanfroemken/ext-kickstarter/main/en-us/Index.html",
 		"email": "froemken@gmail.com",
 		"issues": "https://github.com/froemken/ext-kickstarter/issues",
 		"source": "https://github.com/froemken/ext-kickstarter"

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,10 @@
 		}
 	],
 	"support": {
+        "docs": "https://docs.typo3.org/p/stefanfroemken/ext-kickstarter/main/en-us/Index.html"
 		"email": "froemken@gmail.com",
-		"issues": "https://github.com/froemken/ext_kickstarter/issues",
-		"source": "https://github.com/froemken/ext_kickstarter"
+		"issues": "https://github.com/froemken/ext-kickstarter/issues",
+		"source": "https://github.com/froemken/ext-kickstarter"
 	},
 	"require": {
 		"ext-pdo": "*",
@@ -40,10 +41,6 @@
 		"psr-4": {
 			"StefanFroemken\\ExtKickstarter\\": "Classes"
 		}
-	},
-	"replace": {
-		"typo3-ter/ext_kickstarer": "self.version",
-		"typo3-ter/ext-kickstarer": "self.version"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
Additionally correct link to GitHub and issues (these links will be displayed on packagist and when we use the `:composer:` role in the docs)

Key "replace" is no longer in use and can be removed, see https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/ExtensionArchitecture/FileStructure/ComposerJson.html#properties-no-longer-used