### PR TITLE
[FEATURE] Add preferredExtension to the settings

### DIFF
--- a/Classes/Command/ApplyTypo3CglCommand.php
+++ b/Classes/Command/ApplyTypo3CglCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -36,6 +37,7 @@ class ApplyTypo3CglCommand extends Command
 
     public function __construct(
         private readonly RepositoryCreatorService $repositoryCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -102,7 +104,7 @@ class ApplyTypo3CglCommand extends Command
         }
 
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/ControllerCommand.php
+++ b/Classes/Command/ControllerCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 class ControllerCommand extends Command
 {
@@ -28,6 +29,7 @@ class ControllerCommand extends Command
 
     public function __construct(
         private readonly ControllerCreatorService $controllerCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -60,7 +62,7 @@ class ControllerCommand extends Command
     private function askForControllerInformation(SymfonyStyle $io, InputInterface $input): ControllerInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/EventCommand.php
+++ b/Classes/Command/EventCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 class EventCommand extends Command
 {
@@ -28,6 +29,7 @@ class EventCommand extends Command
 
     public function __construct(
         private readonly EventCreatorService $eventCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -60,7 +62,7 @@ class EventCommand extends Command
     private function askForEventInformation(SymfonyStyle $io, InputInterface $input): EventInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/EventListenerCommand.php
+++ b/Classes/Command/EventListenerCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 class EventListenerCommand extends Command
 {
@@ -28,6 +29,7 @@ class EventListenerCommand extends Command
 
     public function __construct(
         private readonly EventListenerCreatorService $eventListenerCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -60,7 +62,7 @@ class EventListenerCommand extends Command
     private function askForEventListenerInformation(SymfonyStyle $io, InputInterface $input): EventListenerInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/ExtensionCommand.php
+++ b/Classes/Command/ExtensionCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -34,6 +35,7 @@ class ExtensionCommand extends Command
 
     public function __construct(
         private readonly ExtensionCreatorService $extensionCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -62,7 +64,7 @@ class ExtensionCommand extends Command
 
         $extensionInformation = $this->askForExtensionInformation(
             $io,
-            $this->askForExtensionKey($io, $input->getArgument('extension_key'))
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key'), false)
         );
 
         $this->extensionCreatorService->create($extensionInformation);

--- a/Classes/Command/ModelCommand.php
+++ b/Classes/Command/ModelCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
@@ -42,6 +43,7 @@ class ModelCommand extends Command
 
     public function __construct(
         private readonly ModelCreatorService $modelCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -74,7 +76,7 @@ class ModelCommand extends Command
     private function askForModelInformation(SymfonyStyle $io, InputInterface $input): ModelInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/PluginCommand.php
+++ b/Classes/Command/PluginCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class PluginCommand extends Command
@@ -32,6 +33,7 @@ class PluginCommand extends Command
 
     public function __construct(
         private readonly PluginCreatorService $pluginCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -64,7 +66,7 @@ class PluginCommand extends Command
     private function askForPluginInformation(SymfonyStyle $io, InputInterface $input): PluginInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/RepositoryCommand.php
+++ b/Classes/Command/RepositoryCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 class RepositoryCommand extends Command
 {
@@ -28,6 +29,7 @@ class RepositoryCommand extends Command
 
     public function __construct(
         private readonly RepositoryCreatorService $repositoryCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -60,7 +62,7 @@ class RepositoryCommand extends Command
     private function askForRepositoryInformation(SymfonyStyle $io, InputInterface $input): RepositoryInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/TableCommand.php
+++ b/Classes/Command/TableCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class TableCommand extends Command
@@ -30,6 +31,7 @@ class TableCommand extends Command
 
     public function __construct(
         private readonly TableCreatorService $tableCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -62,7 +64,7 @@ class TableCommand extends Command
     private function askForTableInformation(SymfonyStyle $io, InputInterface $input): TableInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/TestEnvCommand.php
+++ b/Classes/Command/TestEnvCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 class TestEnvCommand extends Command
 {
@@ -28,6 +29,7 @@ class TestEnvCommand extends Command
 
     public function __construct(
         private readonly TestEnvCreatorService $testEnvCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -60,7 +62,7 @@ class TestEnvCommand extends Command
     private function askForTestEnvInformation(SymfonyStyle $io, InputInterface $input): TestEnvInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/TypeConverterCommand.php
+++ b/Classes/Command/TypeConverterCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 class TypeConverterCommand extends Command
 {
@@ -28,6 +29,7 @@ class TypeConverterCommand extends Command
 
     public function __construct(
         private readonly TypeConverterCreatorService $typeConverterCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -60,7 +62,7 @@ class TypeConverterCommand extends Command
     private function askForTypeConverterInformation(SymfonyStyle $io, InputInterface $input): TypeConverterInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Command/UpgradeWizardCommand.php
+++ b/Classes/Command/UpgradeWizardCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 class UpgradeWizardCommand extends Command
 {
@@ -28,6 +29,7 @@ class UpgradeWizardCommand extends Command
 
     public function __construct(
         private readonly UpgradeWizardCreatorService $upgradeWizardCreatorService,
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {
         parent::__construct();
     }
@@ -60,7 +62,7 @@ class UpgradeWizardCommand extends Command
     private function askForUpgradeWizardInformation(SymfonyStyle $io, InputInterface $input): UpgradeWizardInformation
     {
         $extensionInformation = $this->getExtensionInformation(
-            $this->askForExtensionKey($io, $input->getArgument('extension_key')),
+            $this->askForExtensionKey($this->extensionConfiguration, $io, $input->getArgument('extension_key')),
             $io
         );
 

--- a/Classes/Configuration/ExtConf.php
+++ b/Classes/Configuration/ExtConf.php
@@ -11,9 +11,8 @@ declare(strict_types=1);
 
 namespace StefanFroemken\ExtKickstarter\Configuration;
 
+use StefanFroemken\ExtKickstarter\Model\Dto\Settings;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
-use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
-use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
 
@@ -25,35 +24,20 @@ final class ExtConf
 {
     private const EXT_KEY = 'ext_kickstarter';
 
-    private const DEFAULT_SETTINGS = [
-        // general
-        'exportDirectory' => '',
-        'activateModule' => false,
-    ];
-
     public function __construct(
         // general
-        private string $exportDirectory = self::DEFAULT_SETTINGS['exportDirectory'],
-        private bool $activateModule = self::DEFAULT_SETTINGS['activateModule'],
+        private string $exportDirectory = Settings::DEFAULT_SETTINGS['exportDirectory'],
+        private bool $activateModule = Settings::DEFAULT_SETTINGS['activateModule'],
     ) {}
 
     public static function create(ExtensionConfiguration $extensionConfiguration): self
     {
-        $extensionSettings = self::DEFAULT_SETTINGS;
-
-        // Overwrite default extension settings with values from EXT_CONF
-        try {
-            $extensionSettings = array_merge(
-                $extensionSettings,
-                $extensionConfiguration->get(self::EXT_KEY),
-            );
-        } catch (ExtensionConfigurationExtensionNotConfiguredException|ExtensionConfigurationPathDoesNotExistException) {
-        }
+        $extensionSettings = Settings::getSettings($extensionConfiguration);
 
         return new self(
             // general
-            exportDirectory: (string)$extensionSettings['exportDirectory'],
-            activateModule: (bool)$extensionSettings['activateModule'],
+            exportDirectory: $extensionSettings->exportDirectory,
+            activateModule: $extensionSettings->activateModule,
         );
     }
 

--- a/Classes/Model/Dto/Settings.php
+++ b/Classes/Model/Dto/Settings.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace StefanFroemken\ExtKickstarter\Model\Dto;
+
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+class Settings
+{
+    private const EXT_KEY = 'ext_kickstarter';
+
+    public const DEFAULT_SETTINGS = [
+        // general
+        'exportDirectory' => '',
+        'preferredExtension' => '',
+        'activateModule' => false,
+    ];
+
+    public function __construct(
+        public readonly string $exportDirectory = self::DEFAULT_SETTINGS['exportDirectory'],
+        public readonly string $preferredExtension = self::DEFAULT_SETTINGS['preferredExtension'],
+        public readonly bool $activateModule = self::DEFAULT_SETTINGS['activateModule'],
+    ) {}
+
+    public static function getSettings(ExtensionConfiguration $extensionConfiguration): Settings
+    {
+        $extensionSettings = Settings::DEFAULT_SETTINGS;
+
+        // Overwrite default extension settings with values from EXT_CONF
+        try {
+            $extensionSettings = array_merge(
+                $extensionSettings,
+                $extensionConfiguration->get(self::EXT_KEY),
+            );
+        } catch (ExtensionConfigurationExtensionNotConfiguredException|ExtensionConfigurationPathDoesNotExistException) {
+        }
+        return new Settings($extensionSettings['exportDirectory'], $extensionSettings['preferredExtension'], $extensionSettings['activateModule']);
+    }
+}

--- a/Classes/Traits/AskForExtensionKeyTrait.php
+++ b/Classes/Traits/AskForExtensionKeyTrait.php
@@ -11,19 +11,26 @@ declare(strict_types=1);
 
 namespace StefanFroemken\ExtKickstarter\Traits;
 
+use StefanFroemken\ExtKickstarter\Model\Dto\Settings;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 trait AskForExtensionKeyTrait
 {
-    private function askForExtensionKey(SymfonyStyle $io, ?string $defaultExtensionKey = null): string
+    private function askForExtensionKey(ExtensionConfiguration $extensionConfiguration, SymfonyStyle $io, ?string $defaultExtensionKey = null, bool $suggestFromSettings = true): string
     {
+        $extensionSettings = Settings::getSettings($extensionConfiguration);
         $io->text([
             'Building a new TYPO3 extension needs a unique identifier, the so called extension key. See:',
             'https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/BestPractises/ExtensionKey.html',
         ]);
 
         do {
-            $extensionKey = (string)$io->ask('Please provide the key for your extension', $defaultExtensionKey);
+            $default = $defaultExtensionKey;
+            if ($suggestFromSettings) {
+                $default = $default ?? $extensionSettings->preferredExtension;
+            }
+            $extensionKey = (string)$io->ask('Please provide the key for your extension', $default);
             $length = mb_strlen($extensionKey);
 
             if ($length < 3 || $length > 30) {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,4 +1,6 @@
 # cat=basic; type=string; label=Export Directory: If not set "typo3temp/ext-kickstarter/" will be used. For composer environment we prefer "packages/"
 exportDirectory =
+# cat=basic; type=string; label=Preferred Extension: If se this extension will be offered as default extension to work on
+preferredExtension =
 # cat=basic; type=boolean; label=Activate Backend Module: The extension kickstarter contains a visual backend module to create new extension, but it's in a very unstable state. Activate if you are really sure to see or use it
 activateModule = 0


### PR DESCRIPTION
- If preferredExtension is set it will be used as default in the prompts
- Default from settings will not be used for make:extension as you are creating a new one then.
- Modeled extension settings as a DTO so they are type safe and reusable