### PR TITLE
[TASK] Update to TYPO3 Rector 3.6

### DIFF
--- a/Build/rector/composer.json
+++ b/Build/rector/composer.json
@@ -1,8 +1,7 @@
 {
-	"name": "t3docs/blog-example-rector",
+	"name": "froemken/kickstarter-rector",
 	"description": "Rector in its own package to avoid compability issues.",
 	"license": "GPL-2.0-or-later",
-	"type": "typo3-cms-extension",
 	"authors": [
 		{
 			"name": "Stefan Froemken",
@@ -11,7 +10,7 @@
 		}
 	],
 	"require": {
-		"ssch/typo3-rector": "^2.3"
+		"ssch/typo3-rector": "^3.6"
 	},
 	"config": {
 		"bin-dir": ".Build/bin",


### PR DESCRIPTION
Since TYPO3 Rector is installed standalone, it can also run under the latest version