### PR TITLE
[FEATURE] Offer to create default TypoScript for Extbase Plugins

### DIFF
--- a/Classes/Command/PluginCommand.php
+++ b/Classes/Command/PluginCommand.php
@@ -82,7 +82,10 @@ class PluginCommand extends Command
         );
 
         $referencedControllerActions = [];
+        $isTypoScriptCreation = false;
+        $set = null;
         $isExtbasePlugin = $io->confirm('Do you prefer to create an extbase based plugin?');
+        $templatePath = '';
         if ($isExtbasePlugin) {
             $extbaseControllerClassnames = $extensionInformation->getExtbaseControllerClassnames();
             if ($extbaseControllerClassnames === []) {
@@ -98,6 +101,22 @@ class PluginCommand extends Command
                 $extbaseControllerClassnames,
                 $extensionInformation,
             );
+            $isTypoScriptCreation = $io->confirm('Do you want to create the default TypoScript for plugin.tx_myextension_myplugin?');
+            if ($isTypoScriptCreation) {
+                $setOptions = array_merge([$extensionInformation->getDefaultTypoScriptPath()], $extensionInformation->getSets());
+
+                // Ask user to choose one (no default)
+                $set = $io->choice(
+                    'To which set do you want to add the TypoScript?',
+                    $setOptions,
+                    null // ← No default choice
+                );
+
+                $templatePath = $io->ask(
+                    'To which path do you want to add the Fluid templates?',
+                    sprintf('EXT:%s/Resources/Private/', $extensionInformation->getExtensionKey())
+                );
+            }
         }
 
         return new PluginInformation(
@@ -107,6 +126,9 @@ class PluginCommand extends Command
             $pluginName,
             $pluginDescription,
             $referencedControllerActions,
+            $isTypoScriptCreation,
+            $set,
+            $templatePath,
         );
     }
 

--- a/Classes/Command/PluginCommand.php
+++ b/Classes/Command/PluginCommand.php
@@ -83,7 +83,7 @@ class PluginCommand extends Command
 
         $referencedControllerActions = [];
         $isTypoScriptCreation = false;
-        $set = null;
+        $typoScriptSet = null;
         $isExtbasePlugin = $io->confirm('Do you prefer to create an extbase based plugin?');
         $templatePath = '';
         if ($isExtbasePlugin) {
@@ -106,10 +106,9 @@ class PluginCommand extends Command
                 $setOptions = array_merge([$extensionInformation->getDefaultTypoScriptPath()], $extensionInformation->getSets());
 
                 // Ask user to choose one (no default)
-                $set = $io->choice(
-                    'To which set do you want to add the TypoScript?',
+                $typoScriptSet = $io->choice(
+                    'To which set (site set or default path) do you want to add the TypoScript?',
                     $setOptions,
-                    null // ← No default choice
                 );
 
                 $templatePath = $io->ask(
@@ -127,7 +126,7 @@ class PluginCommand extends Command
             $pluginDescription,
             $referencedControllerActions,
             $isTypoScriptCreation,
-            $set,
+            $typoScriptSet,
             $templatePath,
         );
     }

--- a/Classes/Creator/Plugin/Extbase/ExtbaseConfigurePluginCreator.php
+++ b/Classes/Creator/Plugin/Extbase/ExtbaseConfigurePluginCreator.php
@@ -31,6 +31,9 @@ use StefanFroemken\ExtKickstarter\PhpParser\Structure\UseStructure;
 use StefanFroemken\ExtKickstarter\Traits\FileStructureBuilderTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * Configures the Extbase plugin in the ext_localconf.php
+ */
 class ExtbaseConfigurePluginCreator implements ExtbasePluginCreatorInterface
 {
     use FileStructureBuilderTrait;

--- a/Classes/Creator/Plugin/Extbase/ExtbaseRegisterPluginCreator.php
+++ b/Classes/Creator/Plugin/Extbase/ExtbaseRegisterPluginCreator.php
@@ -27,6 +27,9 @@ use StefanFroemken\ExtKickstarter\PhpParser\Structure\UseStructure;
 use StefanFroemken\ExtKickstarter\Traits\FileStructureBuilderTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * Registers the Extbase plugin in the TCA/Overrides
+ */
 class ExtbaseRegisterPluginCreator implements ExtbasePluginCreatorInterface
 {
     use FileStructureBuilderTrait;

--- a/Classes/Creator/Plugin/Extbase/ExtbaseTypoScriptPluginCreator.php
+++ b/Classes/Creator/Plugin/Extbase/ExtbaseTypoScriptPluginCreator.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 
 namespace StefanFroemken\ExtKickstarter\Creator\Plugin\Extbase;
 
-use PhpParser\BuilderFactory;
 use StefanFroemken\ExtKickstarter\Information\PluginInformation;
-use StefanFroemken\ExtKickstarter\PhpParser\NodeFactory;
 use StefanFroemken\ExtKickstarter\Traits\FileStructureBuilderTrait;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -23,16 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class ExtbaseTypoScriptPluginCreator implements ExtbasePluginCreatorInterface
 {
     use FileStructureBuilderTrait;
-
-    private BuilderFactory $builderFactory;
-
-    private NodeFactory $nodeFactory;
-
-    public function __construct(NodeFactory $nodeFactory)
-    {
-        $this->builderFactory = new BuilderFactory();
-        $this->nodeFactory = $nodeFactory;
-    }
 
     public function create(PluginInformation $pluginInformation): void
     {

--- a/Classes/Creator/Plugin/Extbase/ExtbaseTypoScriptPluginCreator.php
+++ b/Classes/Creator/Plugin/Extbase/ExtbaseTypoScriptPluginCreator.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package stefanfroemken/ext-kickstarter.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace StefanFroemken\ExtKickstarter\Creator\Plugin\Extbase;
+
+use PhpParser\BuilderFactory;
+use StefanFroemken\ExtKickstarter\Information\PluginInformation;
+use StefanFroemken\ExtKickstarter\PhpParser\NodeFactory;
+use StefanFroemken\ExtKickstarter\Traits\FileStructureBuilderTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Creates the default TypoScript for an Extbase Plugin
+ */
+class ExtbaseTypoScriptPluginCreator implements ExtbasePluginCreatorInterface
+{
+    use FileStructureBuilderTrait;
+
+    private BuilderFactory $builderFactory;
+
+    private NodeFactory $nodeFactory;
+
+    public function __construct(NodeFactory $nodeFactory)
+    {
+        $this->builderFactory = new BuilderFactory();
+        $this->nodeFactory = $nodeFactory;
+    }
+
+    public function create(PluginInformation $pluginInformation): void
+    {
+        if (!$pluginInformation->isTypoScriptCreation()) {
+            return;
+        }
+
+        $extensionInfo = $pluginInformation->getExtensionInformation();
+        $pluginNamespace = $pluginInformation->getTypoScriptPluginNamespace();
+        $pluginMarker = 'plugin.' . $pluginNamespace;
+        $templatePath = $pluginInformation->getTemplatePath();
+
+        // Determine the correct path based on whether using default or named set
+        $path = ($pluginInformation->getSet() === $extensionInfo->getDefaultTypoScriptPath())
+            ? $extensionInfo->getDefaultTypoScriptPath()
+            : $extensionInfo->getSetPath() . $pluginInformation->getSet() . DIRECTORY_SEPARATOR;
+
+        GeneralUtility::mkdir_deep($path);
+
+        $targetSetupFile = $path . 'setup.typoscript';
+        $targetConstantFile = $path . 'constants.typoscript';
+
+        // ----- SETUP -----
+        $setupContent = is_file($targetSetupFile) ? file_get_contents($targetSetupFile) : '';
+
+        if (!str_contains($setupContent, $pluginMarker)) {
+            $setupContent = rtrim($setupContent);
+            if ($setupContent !== '') {
+                $setupContent .= PHP_EOL . PHP_EOL;
+            }
+            $setupContent .= sprintf(
+                <<<'EOT'
+%1$s {
+    view {
+        templateRootPaths.0 = %2$sTemplates/
+        templateRootPaths.10 = {$%1$s.view.templateRootPath}
+        partialRootPaths.0 = %2$sPartials/
+        partialRootPaths.10 = {$%1$s.view.partialRootPath}
+        layoutRootPaths.0 = %2$sLayouts/
+        layoutRootPaths.10 = {$%1$s.view.layoutRootPath}
+    }
+    persistence {
+        storagePid = {$plugin.%1$s.persistence.storagePid}
+    }
+}
+
+EOT,
+                $pluginMarker,
+                $templatePath
+            );
+
+            file_put_contents($targetSetupFile, $setupContent);
+        }
+
+        // ----- CONSTANTS -----
+        $constantContent = is_file($targetConstantFile) ? file_get_contents($targetConstantFile) : '';
+
+        if (!str_contains($constantContent, $pluginMarker)) {
+            $constantContent = rtrim($constantContent);
+            if ($constantContent !== '') {
+                $constantContent .= PHP_EOL . PHP_EOL;
+            }
+            $constantContent .= sprintf(
+                <<<'EOT'
+%1$s {
+    view {
+        templateRootPath = %2$sTemplates/
+        partialRootPath = %2$sPartials/
+        layoutRootPath = %2$sLayouts/
+    }
+    persistence {
+        storagePid = 0
+    }
+}
+
+EOT,
+                $pluginMarker,
+                $templatePath
+            );
+
+            file_put_contents($targetConstantFile, $constantContent);
+        }
+    }
+}

--- a/Classes/Creator/Plugin/Extbase/PluginIconCreator.php
+++ b/Classes/Creator/Plugin/Extbase/PluginIconCreator.php
@@ -14,6 +14,9 @@ namespace StefanFroemken\ExtKickstarter\Creator\Plugin\Extbase;
 use StefanFroemken\ExtKickstarter\Information\PluginInformation;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * Creates an icon for the plugin
+ */
 class PluginIconCreator implements ExtbasePluginCreatorInterface
 {
     public function create(PluginInformation $pluginInformation): void

--- a/Classes/Creator/Plugin/Extbase/RegisterPluginIconIdentifierCreator.php
+++ b/Classes/Creator/Plugin/Extbase/RegisterPluginIconIdentifierCreator.php
@@ -25,6 +25,9 @@ use StefanFroemken\ExtKickstarter\PhpParser\Structure\ReturnStructure;
 use StefanFroemken\ExtKickstarter\PhpParser\Structure\UseStructure;
 use StefanFroemken\ExtKickstarter\Traits\FileStructureBuilderTrait;
 
+/**
+ * Registers the plugin icon into Icons.php
+ */
 class RegisterPluginIconIdentifierCreator implements ExtbasePluginCreatorInterface
 {
     use FileStructureBuilderTrait;

--- a/Classes/Information/ExtensionInformation.php
+++ b/Classes/Information/ExtensionInformation.php
@@ -30,7 +30,7 @@ readonly class ExtensionInformation
         'l10n_diffsource',
     ];
 
-    private const SET_PATH = 'Configuration/Sets/';
+    private const SITE_SET_PATH = 'Configuration/Sets/';
 
     private const TCA_PATH = 'Configuration/TCA/';
 
@@ -153,7 +153,7 @@ readonly class ExtensionInformation
 
     public function getSetPath(): string
     {
-        return $this->getExtensionPath() . self::SET_PATH;
+        return $this->getExtensionPath() . self::SITE_SET_PATH;
     }
 
     public function getDefaultTypoScriptPath(): string

--- a/Classes/Information/ExtensionInformation.php
+++ b/Classes/Information/ExtensionInformation.php
@@ -30,6 +30,8 @@ readonly class ExtensionInformation
         'l10n_diffsource',
     ];
 
+    private const SET_PATH = 'Configuration/Sets/';
+
     private const TCA_PATH = 'Configuration/TCA/';
 
     private const CONTROLLER_PATH = 'Classes/Controller/';
@@ -37,6 +39,8 @@ readonly class ExtensionInformation
     private const MODEL_PATH = 'Classes/Domain/Model/';
 
     private const TCA_OVERRIDES_PATH = 'Configuration/TCA/Overrides/';
+
+    private const TYPOSCRIPT_DEFAULT_PATH = 'Configuration/TypoScript/';
 
     public function __construct(
         private string $extensionKey,
@@ -145,6 +149,16 @@ readonly class ExtensionInformation
     public function getModelPath(): string
     {
         return $this->getExtensionPath() . self::MODEL_PATH;
+    }
+
+    public function getSetPath(): string
+    {
+        return $this->getExtensionPath() . self::SET_PATH;
+    }
+
+    public function getDefaultTypoScriptPath(): string
+    {
+        return $this->getExtensionPath() . self::TYPOSCRIPT_DEFAULT_PATH;
     }
 
     public function getTcaPath(): string
@@ -289,6 +303,37 @@ readonly class ExtensionInformation
         sort($extbaseControllerActionNames);
 
         return $extbaseControllerActionNames;
+    }
+
+    /**
+     * @return string[] All directories in folder Configuration/Sets/ that contain a config.yaml
+     */
+    public function getSets(): array
+    {
+        $setPath = $this->getSetPath();
+
+        if (!is_dir($setPath)) {
+            return [];
+        }
+
+        $sets = [];
+
+        foreach (scandir($setPath) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $fullDirPath = $setPath . DIRECTORY_SEPARATOR . $entry;
+            $configFilePath = $fullDirPath . DIRECTORY_SEPARATOR . 'config.yaml';
+
+            if (is_dir($fullDirPath) && is_file($configFilePath)) {
+                $sets[] = $entry;
+            }
+        }
+
+        sort($sets);
+
+        return $sets;
     }
 
     public function getConfiguredTcaTables(): array

--- a/Classes/Information/ExtensionInformation.php
+++ b/Classes/Information/ExtensionInformation.php
@@ -319,10 +319,12 @@ readonly class ExtensionInformation
         $sets = [];
 
         foreach (scandir($setPath) as $entry) {
-            if ($entry === '.' || $entry === '..') {
+            if ($entry === '.') {
                 continue;
             }
-
+            if ($entry === '..') {
+                continue;
+            }
             $fullDirPath = $setPath . DIRECTORY_SEPARATOR . $entry;
             $configFilePath = $fullDirPath . DIRECTORY_SEPARATOR . 'config.yaml';
 

--- a/Classes/Information/PluginInformation.php
+++ b/Classes/Information/PluginInformation.php
@@ -22,6 +22,9 @@ readonly class PluginInformation
         private string $pluginName,
         private string $pluginDescription,
         private array $referencedControllerActions,
+        private bool $typoScriptCreation = false,
+        private string $set = '',
+        private string $templatePath = '',
     ) {}
 
     public function getExtensionInformation(): ExtensionInformation
@@ -104,5 +107,32 @@ readonly class PluginInformation
             str_replace('_', '', $this->extensionInformation->getExtensionKey()),
             strtolower($this->pluginName),
         );
+    }
+
+    /**
+     * Needed for core native plugins
+     */
+    public function getTypoScriptPluginNamespace(): string
+    {
+        return sprintf(
+            'tx_%s_%s',
+            str_replace('_', '', $this->extensionInformation->getExtensionKey()),
+            strtolower($this->pluginName),
+        );
+    }
+
+    public function isTypoScriptCreation(): bool
+    {
+        return $this->typoScriptCreation;
+    }
+
+    public function getSet(): string
+    {
+        return $this->set;
+    }
+
+    public function getTemplatePath(): string
+    {
+        return $this->templatePath;
     }
 }


### PR DESCRIPTION
When an Extbase plugin is created offer to
create the default TypoScript to register
template paths and storagePid.

The TypoScript can be saved to a Set if one exists or to the default path Configuration/TypoScript

Resolves: https://github.com/froemken/ext-kickstarter/issues/41