### PR TITLE
[BUGFIX] Limit rector to extension files.

### DIFF
--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -14,7 +14,8 @@ use Ssch\TYPO3Rector\Set\Typo3SetList;
 
 return RectorConfig::configure()
     ->withPaths([
-        __DIR__ . '/../../',
+        __DIR__ . '/../../Classes',
+        __DIR__ . '/../../Configuration',
     ])
     // uncomment to reach your current PHP version
     // ->withPhpSets()


### PR DESCRIPTION
Currently rector tries to check all files including those in the build folder and is therefore taking forever to complete.