### PR TITLE
Group created files with same severity to one IO output

### DIFF
--- a/Classes/Command/ExtensionCommand.php
+++ b/Classes/Command/ExtensionCommand.php
@@ -79,10 +79,11 @@ class ExtensionCommand extends Command
 
         $path = $extensionInformation->getExtensionPath();
 
-        $io->success(sprintf('The extension was saved to path %s', $path));
-        $this->printInstallationInstructions($commandContext, $path, $extensionInformation);
-
         $this->printCreatorInformation($extensionInformation->getCreatorInformation(), $commandContext);
+
+        $io->success(sprintf('The extension was saved to path %s', $path));
+
+        $this->printInstallationInstructions($commandContext, $path, $extensionInformation);
 
         return Command::SUCCESS;
     }

--- a/Classes/Traits/CreatorInformationTrait.php
+++ b/Classes/Traits/CreatorInformationTrait.php
@@ -7,20 +7,31 @@ namespace FriendsOfTYPO3\Kickstarter\Traits;
 use FriendsOfTYPO3\Kickstarter\Context\CommandContext;
 use FriendsOfTYPO3\Kickstarter\Enums\FileModificationType;
 use FriendsOfTYPO3\Kickstarter\Information\CreatorInformation;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 
 trait CreatorInformationTrait
 {
     private function printCreatorInformation(CreatorInformation $creatorInformation, CommandContext $commandContext): void
     {
         $io = $commandContext->getIo();
+        $fileMessages = [];
         foreach ($creatorInformation->getFileModifications() as $fileModification) {
             match ($fileModification->getFileModificationType()) {
-                FileModificationType::CREATED => $io->success('File ' . $fileModification->getPath() . ' was created. '),
-                FileModificationType::MODIFIED => $io->success('File ' . $fileModification->getPath() . ' was modified. '),
-                FileModificationType::NOT_MODIFIED => $io->warning('File ' . $fileModification->getPath() . ' does not need to be modified:  ' . $fileModification->getMessage()),
-                FileModificationType::CREATION_FAILED => $io->error('File ' . $fileModification->getPath() . ' could not be created: ' . $fileModification->getMessage()),
-                FileModificationType::MODIFICATION_FAILED => $io->error('File ' . $fileModification->getPath() . ' could not be modified: ' . $fileModification->getMessage()),
-                default => $io->error('Something went wrong: ' . $fileModification->getMessage()),
+                FileModificationType::CREATED => $fileMessages[ContextualFeedbackSeverity::OK->name][] = 'File ' . $fileModification->getPath() . ' was created.',
+                FileModificationType::MODIFIED => $fileMessages[ContextualFeedbackSeverity::OK->name][] = 'File ' . $fileModification->getPath() . ' was modified.',
+                FileModificationType::NOT_MODIFIED => $fileMessages[ContextualFeedbackSeverity::WARNING->name][] = 'File ' . $fileModification->getPath() . ' does not need to be modified: ' . $fileModification->getMessage(),
+                FileModificationType::CREATION_FAILED => $fileMessages[ContextualFeedbackSeverity::ERROR->name][] = 'File ' . $fileModification->getPath() . ' could not be created: ' . $fileModification->getMessage(),
+                FileModificationType::MODIFICATION_FAILED => $fileMessages[ContextualFeedbackSeverity::ERROR->name][] = 'File ' . $fileModification->getPath() . ' could not be modified: ' . $fileModification->getMessage(),
+                default => $fileMessages[ContextualFeedbackSeverity::ERROR->name][] = 'Something went wrong: ' . $fileModification->getMessage(),
+            };
+        }
+
+        foreach ($fileMessages as $severity => $fileMessagesWithSeverity) {
+            match ($severity) {
+                ContextualFeedbackSeverity::OK->name => $io->success($fileMessagesWithSeverity),
+                ContextualFeedbackSeverity::WARNING->name => $io->warning($fileMessagesWithSeverity),
+                ContextualFeedbackSeverity::ERROR->name => $io->error($fileMessagesWithSeverity),
+                default => $io->note($fileMessagesWithSeverity),
             };
         }
     }


### PR DESCRIPTION
Instead of showing an output for each created file while executing make:extension I have grouped created files of same severity to an array. That way we get just ONE output with all created files.

Further I show created files first, then show the output path, and then how to install the extension.

Now, it looks much better:

```
[OK]
...
     File /var/www/html/packages/cars/Configuration/Services.yaml was created.                                         
                                                                                                                        
[OK] The extension was saved to path /var/www/html/packages/cars/                                                      
                                                                                                                        
Install the extension with Composer using:
composer req stefanfroemken/cars:@dev
```

Before the install instructions were above the created files. I had to scroll up a bit to see these instructions. These should be the last output.