### PR TITLE
[BUGFIX] Fix make:plugin with no TypoScript creation

### DIFF
--- a/Classes/Information/PluginInformation.php
+++ b/Classes/Information/PluginInformation.php
@@ -24,7 +24,7 @@ readonly class PluginInformation
         private array $referencedControllerActions,
         private CreatorInformation $creatorInformation = new CreatorInformation(),
         private bool $typoScriptCreation = false,
-        private string $set = '',
+        private ?string $set = '',
         private string $templatePath = '',
     ) {}
 


### PR DESCRIPTION
This was causing a fatal error because $set was not nullable

Releases: main, 13.4