### PR TITLE
[TASK] Ask for Composer name first

### DIFF
--- a/Classes/Command/ExtensionCommand.php
+++ b/Classes/Command/ExtensionCommand.php
@@ -38,10 +38,9 @@ class ExtensionCommand extends Command
 
     public function __construct(
         private readonly ExtensionCreatorService $extensionCreatorService,
-        private readonly QuestionCollection      $questionCollection,
-        private readonly Registry                $registry,
-    )
-    {
+        private readonly QuestionCollection $questionCollection,
+        private readonly Registry $registry,
+    ) {
         parent::__construct();
     }
 


### PR DESCRIPTION
This makes creating extensions faster and easier as the extension key can be easily suggested from the composer name while the opposite direction would
need to know the vendor.

#74 then becomes unnecessary

Closes: https://github.com/FriendsOfTYPO3/kickstarter/issues/74
Releases: main, 13.4