### PR TITLE
[FEATURE] Enable make:model to create models for external tables

### DIFF
--- a/Classes/Information/ExtensionInformation.php
+++ b/Classes/Information/ExtensionInformation.php
@@ -387,17 +387,30 @@ class ExtensionInformation
     public function getTcaForTable(string $tableName): array
     {
         $tcaTableFilePath = $this->getFilePathForTcaTable($tableName);
-        if (!is_file($tcaTableFilePath)) {
-            return [];
+
+        // 1) Local TCA file (for this extension)
+        if (is_file($tcaTableFilePath)) {
+            $tca = require $tcaTableFilePath;
+            if (is_array($tca) && $tca !== []) {
+                return $tca;
+            }
         }
 
-        return require $tcaTableFilePath;
+        // 2) Fallback: global TCA (Core / other extensions)
+        if (isset($GLOBALS['TCA'][$tableName]) && is_array($GLOBALS['TCA'][$tableName])) {
+            return $GLOBALS['TCA'][$tableName];
+        }
+
+        return [];
     }
 
     public function getColumnNamesFromTca(array $tableTca): array
     {
-        $columnNames = array_keys($tableTca['columns']);
+        if (!isset($tableTca['columns']) || !is_array($tableTca['columns'])) {
+            return [];
+        }
 
+        $columnNames = array_keys($tableTca['columns']);
         sort($columnNames);
 
         return $columnNames;

--- a/Classes/Service/ExternalTcaTableResolver.php
+++ b/Classes/Service/ExternalTcaTableResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package friendsoftypo3/kickstarter.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FriendsOfTYPO3\Kickstarter\Service;
+
+use FriendsOfTYPO3\Kickstarter\Information\ExtensionInformation;
+use TYPO3\CMS\Core\Schema\Capability\TcaSchemaCapability;
+use TYPO3\CMS\Core\Schema\TcaSchema;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+
+final readonly class ExternalTcaTableResolver
+{
+    public function __construct(
+        private TcaSchemaFactory $tcaSchemaFactory
+    ) {}
+
+    /**
+     * Returns TCA tables that can reasonably be mapped to a domain model:
+     * - not from the current extension
+     * - not sys_* or be_* tables
+     * - not rootLevel = 1
+     * - not hideTable = 1
+     */
+    public function getExternalTcaTables(ExtensionInformation $extension): array
+    {
+        /** @var array<string, TcaSchema> $schemas */
+        $schemas = iterator_to_array($this->tcaSchemaFactory->all());
+
+        $extensionTables = $extension->getConfiguredTcaTables();
+        $result = [];
+
+        foreach ($schemas as $tableName => $schema) {
+            // Skip local extension tables
+            if (in_array($tableName, $extensionTables, true)) {
+                continue;
+            }
+
+            // Skip system and backend tables
+            if (str_starts_with($tableName, 'sys_')) {
+                continue;
+            }
+            if (str_starts_with($tableName, 'be_')) {
+                continue;
+            }
+
+            if ($schema->hasCapability(TcaSchemaCapability::HideInUi)) {
+                continue;
+            }
+
+            if ($schema->hasCapability(TcaSchemaCapability::AccessAdminOnly)) {
+                continue;
+            }
+
+            $result[] = $tableName;
+        }
+
+        sort($result);
+        return $result;
+    }
+}

--- a/Tests/Functional/Integration/Fixtures/my_extension_with_model_fe_group/Classes/Domain/Model/Group.php
+++ b/Tests/Functional/Integration/Fixtures/my_extension_with_model_fe_group/Classes/Domain/Model/Group.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package my-vendor/my-extension.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+namespace MyVendor\MyExtension\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+final class Group extends AbstractEntity
+{
+    protected string $title = '';
+    protected string $description = '';
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+}

--- a/Tests/Functional/Integration/Fixtures/my_extension_with_model_fe_group/Configuration/Extbase/Persistence/Classes.php
+++ b/Tests/Functional/Integration/Fixtures/my_extension_with_model_fe_group/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+use MyVendor\MyExtension\Domain\Model\Group;
+return [
+    Group::class => [
+        'tableName' => 'fe_groups',
+    ],
+];

--- a/Tests/Functional/Integration/ModelCreatorServiceTest.php
+++ b/Tests/Functional/Integration/ModelCreatorServiceTest.php
@@ -149,6 +149,31 @@ class ModelCreatorServiceTest extends AbstractServiceCreatorTestCase
                     FileModificationType::MODIFIED,
                 ],
             ],
+            'add_model_for_core_table' => [
+                'modelClassName' => 'Group',
+                'mappedTableName' => 'fe_groups',
+                'abstractEntity' => true,
+                'properties' => [
+                    [
+                        'propertyName' => 'title',
+                        'dataType' => 'string',
+                        'defaultValue' => '',
+                    ],
+                    [
+                        'propertyName' => 'description',
+                        'dataType' => 'string',
+                        'defaultValue' => '',
+                    ],
+                ],
+                'extensionKey' => 'my_extension',
+                'composerPackageName' => 'my-vendor/my-extension',
+                'expectedDir' => __DIR__ . '/Fixtures/my_extension_with_model_fe_group',
+                'inputPath' => __DIR__ . '/Fixtures/input/my_extension',
+                'createdFileModifications' => [
+                    FileModificationType::CREATED,
+                    FileModificationType::CREATED,
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
 Many extensions need access to TYPO3 Core tables
 like fe_users and pages.

 Some extent another extension and want to create
 their own model for their table.

 This change enables users to create Models for all
 Core tables with TCA that are not limited to the
 admin access and not hidden.

Resolves: https://github.com/FriendsOfTYPO3/kickstarter/issues/179
Releases: main, 13.4