### PR TITLE
[TASK] Rename CGL dry run variable to a generic dry run option

### DIFF
--- a/Classes/Creator/Test/Environment/RunScriptsCreator.php
+++ b/Classes/Creator/Test/Environment/RunScriptsCreator.php
@@ -470,7 +470,7 @@ case ${TEST_SUITE} in
     composerNormalize)
         DRY_RUN_OPTIONS=''
         if [ "${DRY_RUN}" -eq 1 ]; then
-            DRY_RUN_OPTIONS='-n'
+            DRY_RUN_OPTIONS='--dry-run --diff'
         fi
         COMMAND=(composer normalize ${DRY_RUN_OPTIONS})
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"

--- a/Tests/Functional/Integration/Fixtures/make_testenv/Build/Scripts/runTests.sh
+++ b/Tests/Functional/Integration/Fixtures/make_testenv/Build/Scripts/runTests.sh
@@ -423,7 +423,7 @@ case ${TEST_SUITE} in
     composerNormalize)
         DRY_RUN_OPTIONS=''
         if [ "${DRY_RUN}" -eq 1 ]; then
-            DRY_RUN_OPTIONS='-n'
+            DRY_RUN_OPTIONS='--dry-run --diff'
         fi
         COMMAND=(composer normalize ${DRY_RUN_OPTIONS})
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"


### PR DESCRIPTION
The variable `CGLCHECK_DRY_RUN` was specifically named for PHP-CS-Fixer (Coding Guide Line) checks. Since the dry run flag (usually triggered via the `-n` option) is also applicable to other integrated tools like Rector, TYPO3 Fractor, and Composer Normalize, the variable has been renamed to `DRY_RUN_OPTIONS`.

This change allows the dry run state to be shared across multiple test suites, ensuring consistent behavior when running automated refactoring or formatting tools in a non-destructive mode.