### PR TITLE
[TASK] Correct typo in MiddlewareInformation class name

### DIFF
--- a/Classes/Command/MiddlewareCommand.php
+++ b/Classes/Command/MiddlewareCommand.php
@@ -16,7 +16,7 @@ use FriendsOfTYPO3\Kickstarter\Command\Input\Question\Middleware\MiddlewareClass
 use FriendsOfTYPO3\Kickstarter\Command\Input\Question\Middleware\MiddlewareIdentifierQuestion;
 use FriendsOfTYPO3\Kickstarter\Command\Input\QuestionCollection;
 use FriendsOfTYPO3\Kickstarter\Context\CommandContext;
-use FriendsOfTYPO3\Kickstarter\Information\MiddleWareInformation;
+use FriendsOfTYPO3\Kickstarter\Information\MiddlewareInformation;
 use FriendsOfTYPO3\Kickstarter\Service\Creator\MiddlewareCreatorService;
 use FriendsOfTYPO3\Kickstarter\Traits\AskForExtensionKeyTrait;
 use FriendsOfTYPO3\Kickstarter\Traits\CreatorInformationTrait;

--- a/Classes/Creator/Middleware/MiddlewareCreator.php
+++ b/Classes/Creator/Middleware/MiddlewareCreator.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Kickstarter\Creator\Middleware;
 
 use FriendsOfTYPO3\Kickstarter\Creator\FileManager;
-use FriendsOfTYPO3\Kickstarter\Information\MiddleWareInformation;
+use FriendsOfTYPO3\Kickstarter\Information\MiddlewareInformation;
 use FriendsOfTYPO3\Kickstarter\PhpParser\NodeFactory;
 use FriendsOfTYPO3\Kickstarter\PhpParser\Structure\ClassStructure;
 use FriendsOfTYPO3\Kickstarter\PhpParser\Structure\DeclareStructure;

--- a/Classes/Creator/Middleware/MiddlewareCreatorInterface.php
+++ b/Classes/Creator/Middleware/MiddlewareCreatorInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Kickstarter\Creator\Middleware;
 
-use FriendsOfTYPO3\Kickstarter\Information\MiddleWareInformation;
+use FriendsOfTYPO3\Kickstarter\Information\MiddlewareInformation;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 #[AutoconfigureTag('ext-kickstarter.creator.middleware')]

--- a/Classes/Creator/Middleware/RequestMiddlewaresCreator.php
+++ b/Classes/Creator/Middleware/RequestMiddlewaresCreator.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Kickstarter\Creator\Middleware;
 
 use FriendsOfTYPO3\Kickstarter\Creator\FileManager;
-use FriendsOfTYPO3\Kickstarter\Information\MiddleWareInformation;
+use FriendsOfTYPO3\Kickstarter\Information\MiddlewareInformation;
 use FriendsOfTYPO3\Kickstarter\PhpParser\Structure\FileStructure;
 use FriendsOfTYPO3\Kickstarter\PhpParser\Structure\ReturnStructure;
 use FriendsOfTYPO3\Kickstarter\Traits\FileStructureBuilderTrait;
@@ -67,7 +67,7 @@ class RequestMiddlewaresCreator implements MiddlewareCreatorInterface
         );
     }
 
-    private function addStackEntry(string $filePath, FileStructure $fileStructure, MiddleWareInformation $middlewareInformation): bool
+    private function addStackEntry(string $filePath, FileStructure $fileStructure, MiddlewareInformation $middlewareInformation): bool
     {
         /** @var ReturnStructure $returnStructure */
         $returnStructure = $fileStructure->getReturnStructures()->current();
@@ -126,7 +126,7 @@ class RequestMiddlewaresCreator implements MiddlewareCreatorInterface
         return null;
     }
 
-    private function createMiddlewareEntry(MiddleWareInformation $middlewareInformation): ArrayItem
+    private function createMiddlewareEntry(MiddlewareInformation $middlewareInformation): ArrayItem
     {
         $beforeArray = $this->getBeforeAfterArray($middlewareInformation->getBefore());
         $afterArray = $this->getBeforeAfterArray($middlewareInformation->getAfter());

--- a/Classes/Information/MiddlewareInformation.php
+++ b/Classes/Information/MiddlewareInformation.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\Kickstarter\Information;
 
-readonly class MiddleWareInformation
+readonly class MiddlewareInformation
 {
     private const NAMESPACE_PART = 'Middleware';
 

--- a/Classes/Service/Creator/MiddlewareCreatorService.php
+++ b/Classes/Service/Creator/MiddlewareCreatorService.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\Kickstarter\Service\Creator;
 
 use FriendsOfTYPO3\Kickstarter\Creator\Middleware\MiddlewareCreatorInterface;
-use FriendsOfTYPO3\Kickstarter\Information\MiddleWareInformation;
+use FriendsOfTYPO3\Kickstarter\Information\MiddlewareInformation;
 
 readonly class MiddlewareCreatorService
 {


### PR DESCRIPTION
Renames 'MiddleWareInformation' to 'MiddlewareInformation' to follow standard camelCase naming conventions where 'Middleware' is treated as a single word.

Changes:
- Renamed `Classes/Information/MiddleWareInformation.php` to `Classes/Information/MiddlewareInformation.php`.
- Updated the class definition and namespace usage.
- Updated all type hints and use statements in:
    - MiddlewareCommand
    - MiddlewareCreator
    - RequestMiddlewaresCreator
    - MiddlewareCreatorInterface
    - MiddlewareCreatorService