### PR TITLE
CleanUp .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ nbproject
 #
 # Ignore composer stuff
 /bin/*
-/var/*
+/var
 /vendor/*
 /index.php
 /typo3/install.php

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ nbproject
 .tscache
 #
 # Ignore composer stuff
-/bin/*
 /var
 /vendor/*
 /index.php

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ nbproject
 #
 # Ignore composer stuff
 /bin/*
+/var/*
 /vendor/*
 /index.php
 /typo3/install.php

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ nbproject
 #
 # Ignore composer stuff
 /var
-/vendor/*
 /index.php
 /typo3/install.php
 #

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ nbproject
 #
 # Ignore composer stuff
 /var
-/typo3/install.php
 #
 # Ignore common TYPO3 CMS files/directories
 /typo3temp/*

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ nbproject
 #
 # Ignore composer stuff
 /var
-/index.php
 /typo3/install.php
 #
 # Ignore common TYPO3 CMS files/directories


### PR DESCRIPTION
Remove various files and folders which are not valid, as they are part of the already excluded .Build folder.