### PR TITLE
[FEATURE] Add functional tests for ExtConf configuration

### DIFF
--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -13,6 +13,7 @@ use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
+use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 use Rector\ValueObject\PhpVersion;
 use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
@@ -61,6 +62,10 @@ return RectorConfig::configure()
         ],
         FlipTypeControlToUseExclusiveTypeRector::class => [
             '*/Classes/PhpParser/Printer/PrettyTypo3Printer.php',
+        ],
+        // Avoid stripping class types from mock properties to keep IDE autocomplete working in functional tests
+        TypedPropertyFromCreateMockAssignRector::class => [
+            '*/Tests/Functional/*',
         ],
         '*Build/*',
         '*Resources/*',

--- a/Classes/Configuration/ExtConf.php
+++ b/Classes/Configuration/ExtConf.php
@@ -64,16 +64,16 @@ final readonly class ExtConf
         $exportDirectory = trim($this->exportDirectory);
 
         if ($exportDirectory === '' || $exportDirectory === '0') {
-            // Fall back to typo3temp/kickstarter
-            return sprintf(
-                '/%s/%s/',
-                trim(Environment::getPublicPath(), '/'),
-                'typo3temp/kickstarter',
-            );
+            $base = Environment::getPublicPath();
+            $suffix = 'typo3temp/kickstarter';
+        } else {
+            $base = Environment::getProjectPath();
+            $suffix = ltrim($exportDirectory, '/');
         }
 
-        // sprintf() in ExtensionInformation will add trailing slash
-        return Environment::getProjectPath() . '/' . rtrim($exportDirectory, '/');
+        $path = rtrim($base, '/') . '/' . rtrim($suffix, '/');
+
+        return $path === '' ? '/' : $path;
     }
 
     public function isActivateModule(): bool

--- a/Tests/Functional/Configuration/ExtConfTest.php
+++ b/Tests/Functional/Configuration/ExtConfTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package friendsoftypo3/kickstarter.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace FriendsOfTYPO3\Kickstarter\Tests\Functional\Configuration;
+
+use FriendsOfTYPO3\Kickstarter\Configuration\ExtConf;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\ApplicationContext;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class ExtConfTest extends FunctionalTestCase
+{
+    public ExtensionConfiguration|MockObject $extensionConfigurationMock;
+
+    protected array $coreExtensionsToLoad = [
+        'extensionmanager',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'friendsoftypo3/kickstarter',
+    ];
+
+    protected function setUp(): void
+    {
+        $this->extensionConfigurationMock = $this->createMock(ExtensionConfiguration::class);
+
+        Environment::initialize(
+            $this->createMock(ApplicationContext::class),
+            cli: true,
+            composerMode: true,
+            projectPath: '',
+            publicPath: '',
+            varPath: '',
+            configPath: 'config',
+            currentScript: '',
+            os: 'UNIX',
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->extensionConfigurationMock,
+        );
+    }
+
+    #[Test]
+    public function getExportDirectoryInitiallyReturnsTypo3TempPath(): void
+    {
+        $config = [];
+        $subject = new ExtConf(...$config);
+
+        self::assertSame(
+            '/typo3temp/kickstarter',
+            $subject->getExportDirectory(),
+        );
+    }
+
+    public static function exportDirectoryDataProvider(): array
+    {
+        return [
+            'Directory with empty string' => ['', '/typo3temp/kickstarter'],
+            'Directory with zero' => ['0', '/typo3temp/kickstarter'],
+            'Directory with no slashes' => ['packages', '/packages'],
+            'Directory with starting slash' => ['/packages', '/packages'],
+            'Directory with leading slash' => ['packages/', '/packages'],
+            'Directory wrapped with slashes' => ['/packages/', '/packages'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider(
+        methodName: 'exportDirectoryDataProvider',
+    )]
+    public function getExportDirectoryWithExportDirectoryReturnsExportDirectory(
+        string $configuredExportDirectory,
+        string $expectedExportDirectory,
+    ): void {
+        $config = [
+            'exportDirectory' => $configuredExportDirectory,
+        ];
+        $subject = new ExtConf(...$config);
+
+        self::assertSame(
+            $expectedExportDirectory,
+            $subject->getExportDirectory(),
+        );
+    }
+
+    #[Test]
+    public function isActivateModuleInitiallyFalse(): void
+    {
+        $config = [];
+        $subject = new ExtConf(...$config);
+
+        self::assertFalse(
+            $subject->isActivateModule(),
+        );
+    }
+
+    #[Test]
+    public function isActivateModuleWithTrueStillTrue(): void
+    {
+        $config = [
+            'activateModule' => true,
+        ];
+        $subject = new ExtConf(...$config);
+
+        self::assertTrue(
+            $subject->isActivateModule(),
+        );
+    }
+
+    #[Test]
+    public function isActivateModuleWithFalseStillFalse(): void
+    {
+        $config = [
+            'activateModule' => false,
+        ];
+        $subject = new ExtConf(...$config);
+
+        self::assertFalse(
+            $subject->isActivateModule(),
+        );
+    }
+}


### PR DESCRIPTION
Extend functional test coverage by introducing `ExtConfTest` for validating configuration behaviors, including `getExportDirectory` and `isActivateModule`. Improves robustness and ensures expected behavior under diverse conditions.